### PR TITLE
http: add note about clientError event

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1310,7 +1310,8 @@ changes:
 If a client connection emits an `'error'` event, it will be forwarded here.
 Listener of this event is responsible for closing/destroying the underlying
 socket. For example, one may wish to more gracefully close the socket with a
-custom HTTP response instead of abruptly severing the connection.
+custom HTTP response instead of abruptly severing the connection. The socket
+**must be closed or destroyed** before the listener ends.
 
 This event is guaranteed to be passed an instance of the {net.Socket} class,
 a subclass of {stream.Duplex}, unless the user specifies a socket


### PR DESCRIPTION
Add the document that during `clientError` the socket MUST be closed.

Fixes #43548.