### PR TITLE
timers: add sleep alias

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -512,6 +512,10 @@ const interval = 100;
 })();
 ```
 
+### `timersPromises.sleep([delay[, value[, options]]])`
+
+An alias for [`timersPromises.setTimeout()`][].
+
 ### `timersPromises.scheduler.wait(delay[, options])`
 
 <!-- YAML

--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -227,4 +227,5 @@ module.exports = {
   scheduler: ReflectConstruct(function() {
     this[kScheduler] = true;
   }, [], Scheduler),
+  sleep: setTimeout,
 };


### PR DESCRIPTION
During my daily activities I keep doing:

```
const { setTimeout: sleep } = require('timers/promises')
```

(or the ESM equivalent).

This is overly annoying so I think we should export a simple alias.

This also fix a not quite uncommon situation where somebody instead (even by mistake in their IDE) something like:

```
const { setTimeout } = require('timers/promises')

// ...

await setTimeout(1000)

// .. and then somewhere else in the same file

setTimeout(() => {
  // This is not going to be called.
}, 1000)
```

The latter will not call the callback as the user is now using the promisified version.